### PR TITLE
mapping-webapi-official: use rr:IRI for rdf:type

### DIFF
--- a/mapping-webapi-official.rml.ttl
+++ b/mapping-webapi-official.rml.ttl
@@ -290,7 +290,7 @@
           rr:objectMap [ rr:constant "https://schema.org/ParkingFacilitySmartLock"; rr:termType rr:IRI ]
         ];
       ];
-      rr:datatype xsd:string;
+      rr:termType rr:IRI;
     ];
   ];
 


### PR DESCRIPTION
schema:ParkingFacility* is an IRI not a string